### PR TITLE
Refine header query construction

### DIFF
--- a/db_search_export_user_v5.sh
+++ b/db_search_export_user_v5.sh
@@ -97,8 +97,9 @@ _mysql_data() {
 get_table_header_line() {
   local schema_hex="$1"
   local table_hex="$2"
-  _mysql_data "SELECT COLUMN_NAME FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = UNHEX('${schema_hex}') AND TABLE_NAME = UNHEX('${table_hex}') ORDER BY ORDINAL_POSITION;" \
-    | paste -sd $'\t'
+  local query
+  query="SELECT COLUMN_NAME FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = UNHEX('${schema_hex}') AND TABLE_NAME = UNHEX('${table_hex}') ORDER BY ORDINAL_POSITION;"
+  _mysql_data "$query" | paste -sd $'\t'
 }
 
 escape_ident() {


### PR DESCRIPTION
## Summary
- refactor the header retrieval query to build the SQL string in a local variable
- ensure the UNHEX(...) expression for table names remains intact on a single line before execution

## Testing
- `bash db_search_export_user_v5.sh -s test -d mysql` *(fails: xxd missing in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d621f0cb98833286e71620b8503933