### PR TITLE
Escape logfile field in CSV output

### DIFF
--- a/log_search_export_user.sh
+++ b/log_search_export_user.sh
@@ -66,6 +66,7 @@ append_csv() {
   local logfile="$1"
   local record="$2"
   # escape double quotes
+  logfile="${logfile//\"/\"\"}"
   record="${record//\"/\"\"}"
   printf "\"%s\",\"%s\"\n" "$logfile" "$record" >> "$OUTFILE"
 }


### PR DESCRIPTION
## Summary
- escape double quotes in the logfile field before writing CSV rows

## Testing
- Manual: `mkdir -p test_logs && printf 'hello "world" entry\n' > test_logs/access\"log && bash log_search_export_user.sh -s hello -p "test_logs/*" -o test_output.csv`


------
https://chatgpt.com/codex/tasks/task_e_68d6251f73dc8332b580e4650c01c7d2