### PR TITLE
Handle MySQL \Z escape in export decode

### DIFF
--- a/db_search_export_user_v5.sh
+++ b/db_search_export_user_v5.sh
@@ -221,6 +221,7 @@ headers = headers_arg.split("\t") if headers_arg else []
 def decode(value: str) -> str:
     if value in ("NULL", r"\N"):
         return value
+    value = value.replace("\\Z", "\x1a")
     try:
         return codecs.decode(value.encode("utf-8"), "unicode_escape")
     except Exception:
@@ -261,6 +262,7 @@ prefix = [db_name, table_name, column_name]
 def decode(value: str) -> str:
     if value in ("NULL", r"\N"):
         return value
+    value = value.replace("\\Z", "\x1a")
     try:
         return codecs.decode(value.encode("utf-8"), "unicode_escape")
     except Exception:


### PR DESCRIPTION
## Summary
- convert MySQL's literal `\Z` escape to the raw 0x1A byte in both embedded Python decoders
- keep existing NULL sentinels untouched before passing data to `unicode_escape`

## Testing
- python3 - <<'PY' ...

------
https://chatgpt.com/codex/tasks/task_e_68d6428eb4fc8332bbac7fa5357003f6