### PR TITLE
Quote default log globs and add regression test

### DIFF
--- a/log_search_export_user.sh
+++ b/log_search_export_user.sh
@@ -43,7 +43,7 @@ done
 
 # default log paths
 if [[ ${#LOGPATHS[@]} -eq 0 ]]; then
-  LOGPATHS=( /var/log/apache2/*access*.log* /var/log/nginx/*access*.log* )
+  LOGPATHS=( "/var/log/apache2/*access*.log*" "/var/log/nginx/*access*.log*" )
 fi
 
 TS=$(date +"%Y%m%d_%H%M%S")

--- a/tests/log_search_export_user_test.sh
+++ b/tests/log_search_export_user_test.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+script="$repo_root/log_search_export_user.sh"
+
+tmpdir=$(mktemp -d)
+trap 'rm -rf "$tmpdir"' EXIT
+
+logfile="$tmpdir/access log with spaces.log"
+output="$tmpdir/results.csv"
+pattern="needle"
+
+echo "${pattern} entry" > "$logfile"
+
+bash "$script" -s "$pattern" -p "$tmpdir"'/'"*log" -o "$output"
+
+grep -q "access log with spaces.log" "$output"
+
+echo "Test passed: entries with spaces are captured."


### PR DESCRIPTION
## Summary
- quote the default log glob patterns so they remain literal until compgen expansion
- add a regression test to ensure globbed log files with spaces are still discovered and reported

## Testing
- tests/log_search_export_user_test.sh

------
https://chatgpt.com/codex/tasks/task_e_68d644bf0de883329640eb0a06dfbeed